### PR TITLE
Update do not disturb users list

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -256,6 +256,7 @@ export async function makeLastCall() {
     U0RRABABE: 'Martin Macko',
     U0KB8F7MZ: 'Milan Darjanin',
     U0KB15213: 'Andrej Skok',
+    U0KBBGP47: 'Lucia Maršallová',
   };
 
   for (let user of users) {


### PR DESCRIPTION
Je tu problem, ze tieto spravy od Fekiho dostavaju na slacku aj ludia, ktori su iba hostia, takze napriklad nemaju ani pristup do channelu obedy. A v pripade Lucie, ani nie su uz vo Vacuumlabs aby davalo zmysel pre nich si objednat tie obedy.

Neviem ako si na tom casovo, ale nestacilo by pridat do databazy stlpec `do_not_disturb`, ktory je defaultne na `0`? Pokial uzivatel napise Fekimu `mute`, `do not disturb` alebo `dnd`, tak ti to prepne hodnotu pre tento stlpec pre tohto uzivatela v databaze. _(Samozrejme, ze to ma uzivatel napisat by sa mohlo pridat niekde do helpu, alebo ak napises nieco Fekimu, tak ti vrati aj tuto spravu.)_

Nasledne ako volas `'SELECT * FROM users'` v `makeLastCall`, tak to len rozsiris na `'SELECT * FROM users WHERE do_not_disturb=0'`. To by mohlo stacit nie? A nemala byt to privelka zmena. Ja som nerobil nic s botmi, tak stravim privela casu zistovanim ako si to lokalne vyskusat.

Nevznikali by taketo PRs. 🙂 