### PR TITLE
Bugfix/grammar

### DIFF
--- a/messages/help.txt
+++ b/messages/help.txt
@@ -1,5 +1,5 @@
 *ŠALÁT + MÄSO*
-stačí nahlásiť do ~11:00, že budete papať a dostanete šalátik + mäsko, aké si vypýtate z Billy. Bežne býva kuracie stehno, klobáska, no nájde sa občas aj sekaná, prso, bôčik, ...
+stačí nahlásiť do ~11:00, že budete papať a dostanete šalátik + mäsko, aké si vypýtate z Billy. Bežne býva kuracie stehno, klobáska, no nájde sa občas aj sekaná, prsia, bôčik, ...
 
 *Príklad:* `@obedbot: nakup stehno+salat`
 
@@ -23,7 +23,7 @@ Príklad: `@obedbot: veg4p` značí, že si dáte štvorku s polievkou z VegLife
 Dúfame, že si v tom každý najde svoje :slightly_smiling_face:
 
 *MENU*
-Ak sa ti nechce hladať menu na strankach tychto restik, stačí ak do konverzácie na slacku napises `/veglife` alebo `/presto` a zobrazí sa ti menu reštiky na daný deň. Neboj, nikoho tým spamovať nebudeš. Menu je viditelné iba pre teba :slightly_smiling_face:
+Ak sa ti nechce hľadať menu na stránkach týchto reštaurácií, stačí ak do konverzácie na Slacku napíšeš `/veglife` alebo `/presto` a zobrazí sa ti menu danej reštaurácie na daný deň. Neboj, nikoho tým spamovať nebudeš. Menu je viditelné iba pre teba :slightly_smiling_face:
 
 *NOTIFIKÁCIE*
 Ak si chceš zapnúť notifikácie, aby si si nezabudol/dla objednať obed, môže ich zapnúť tak, že napíšeš priamo obedbot-ovi do správy `mute` alebo `unmute`

--- a/messages/help.txt
+++ b/messages/help.txt
@@ -17,7 +17,7 @@ Viete si objednať do 9:40 ľubovoľný obed z menu na stránke, teda buď A, B 
 *Príklad*: `@obedbot: mizzaA`
 
 *VEGLIFE*
-`http://www.veglife.sk/index.php/obedove-menu`
+`http://www.veglife.sk/sk/menu-2/`
 Do 9:40 je možné si nahlásiť veg+číslo+pripadná polievka alebo šalát
 Príklad: `@obedbot: veg4p` značí, že si dáte štvorku s polievkou z VegLife.
 Dúfame, že si v tom každý najde svoje :slightly_smiling_face:

--- a/messages/help.txt
+++ b/messages/help.txt
@@ -8,7 +8,7 @@ stačí nahlásiť do ~11:00, že budete papať a dostanete šalátik + mäsko, 
 Tam si viete objednať do 10:00 v daný deň ľubovoľný obed z denného menu alebo pizzu.
 MENU: Napíšete do Slacku presto+"cislo"+"p"+(1/2), kde 1 alebo 2 na konci je čislo polievky.
 *Príklad:* `@obedbot: presto3p1` - chcem menu 3 s prvou polievkou v poradí na daný deň
-PIZZA: Napíšete do Slacku pizza+"cislo"+"v" (veľkosť) +(33/40/50)
+PIZZA: Napíšete do Slacku pizza+"cislo"+"v" (veľkosť) +(33/40/50).
 *Príklad:* `@obedbot: pizza3v33` - chcem pizzu č. 3 veľkosti 33 cm
 
 *PIZZA MIZZA*
@@ -26,4 +26,4 @@ Dúfame, že si v tom každý najde svoje :slightly_smiling_face:
 Ak sa ti nechce hľadať menu na stránkach týchto reštaurácií, stačí ak do konverzácie na Slacku napíšeš `/presto`, `/mizza` alebo `/veglife` a zobrazí sa ti menu danej reštaurácie na daný deň. Neboj, nikoho tým spamovať nebudeš. Menu je viditelné iba pre teba :slightly_smiling_face:
 
 *NOTIFIKÁCIE*
-Ak si chceš zapnúť notifikácie, aby si si nezabudol/dla objednať obed, môže ich zapnúť tak, že napíšeš priamo obedbot-ovi do správy `mute` alebo `unmute`
+Ak si chceš zapnúť notifikácie, aby si si nezabudol/dla objednať obed, môžeš ich zapnúť tak, že napíšeš priamo obedbot-ovi do správy `mute` alebo `unmute`

--- a/messages/help.txt
+++ b/messages/help.txt
@@ -1,7 +1,10 @@
-*ŠALÁT + MÄSO*
-stačí nahlásiť do ~11:00, že budete papať a dostanete šalátik + mäsko, aké si vypýtate z Billy. Bežne býva kuracie stehno, klobáska, no nájde sa občas aj sekaná, prsia, bôčik, ...
+*STÁLA PONUKA*
+Každý deň sa v kuchyni pripravujú pečené kuracie stehná (asi 3kg) a dusená zelenina.
+Je to k dispozícii bez objednávania pre každého, až kým sa to nezje.
+V kuchyni sa tiež nachádzajú rôzne druhy zeleniny, ovocia, orieškov a iné pochutiny, ktorými sa môžete ponúknuť.
+Ak by ste chceli, aby sa do kuchyne nakúpilo ešte niečo ďalšie, môžete to nahlásiť takto:
 
-*Príklad:* `@obedbot: nakup stehno+salat`
+*Príklad:* `@obedbot: nakup makadamové orechy`
 
 *PIZZA PRESTO*
 `http://www.pizza-presto.sk/default.aspx?p=catalogpage&group=1`

--- a/messages/help.txt
+++ b/messages/help.txt
@@ -23,7 +23,7 @@ Príklad: `@obedbot: veg4p` značí, že si dáte štvorku s polievkou z VegLife
 Dúfame, že si v tom každý najde svoje :slightly_smiling_face:
 
 *MENU*
-Ak sa ti nechce hľadať menu na stránkach týchto reštaurácií, stačí ak do konverzácie na Slacku napíšeš `/presto`, `/mizza` alebo `/veglife` a zobrazí sa ti menu danej reštaurácie na daný deň. Neboj, nikoho tým spamovať nebudeš. Menu je viditelné iba pre teba :slightly_smiling_face:
+Ak sa vám nechce hľadať menu na stránkach týchto reštaurácií, stačí ak do konverzácie na Slacku napíšete `/presto`, `/mizza` alebo `/veglife` a zobrazí sa vám menu danej reštaurácie na daný deň. Nikoho tým spamovať nebudete, pretože odpoveď je viditelná iba pre vás :slightly_smiling_face:.
 
 *NOTIFIKÁCIE*
-Ak si chceš zapnúť notifikácie, aby si si nezabudol/dla objednať obed, môžeš ich zapnúť tak, že napíšeš priamo obedbot-ovi do správy `mute` alebo `unmute`
+Ak si chcete zapnúť notifikácie, aby ste si nezabudli objednať obed, môžete to urobiť tak, že napíšete priamo obedbot-ovi do správy `mute` alebo `unmute`.

--- a/messages/help.txt
+++ b/messages/help.txt
@@ -23,7 +23,7 @@ Príklad: `@obedbot: veg4p` značí, že si dáte štvorku s polievkou z VegLife
 Dúfame, že si v tom každý najde svoje :slightly_smiling_face:
 
 *MENU*
-Ak sa ti nechce hľadať menu na stránkach týchto reštaurácií, stačí ak do konverzácie na Slacku napíšeš `/veglife` alebo `/presto` a zobrazí sa ti menu danej reštaurácie na daný deň. Neboj, nikoho tým spamovať nebudeš. Menu je viditelné iba pre teba :slightly_smiling_face:
+Ak sa ti nechce hľadať menu na stránkach týchto reštaurácií, stačí ak do konverzácie na Slacku napíšeš `/presto`, `/mizza` alebo `/veglife` a zobrazí sa ti menu danej reštaurácie na daný deň. Neboj, nikoho tým spamovať nebudeš. Menu je viditelné iba pre teba :slightly_smiling_face:
 
 *NOTIFIKÁCIE*
 Ak si chceš zapnúť notifikácie, aby si si nezabudol/dla objednať obed, môže ich zapnúť tak, že napíšeš priamo obedbot-ovi do správy `mute` alebo `unmute`

--- a/src/utils.js
+++ b/src/utils.js
@@ -132,8 +132,8 @@ export function saveUser(userId) {
       if (!config.dev) {
         slack.web.chat.postMessage(
           channelId,
-          'Ahoj, volám sa obedbot, našiel som ťa v channely #obedy ' +
-          'a nemal som ťa ešte v mojom zápisníčku, tak si ťa poznamenávam, ' +
+          'Ahoj, volám sa obedbot a všimol som si ťa na kanáli #obedy ' +
+          'ale nemal som ťa ešte v mojom zápisníčku, tak si ťa poznamenávam, ' +
           'budem ti odteraz posielať last cally, pokiaľ v daný deň nemáš nič objednané :)',
           {as_user: true}
         );
@@ -151,7 +151,7 @@ export function saveUser(userId) {
               if (!config.dev) {
                 slack.web.chat.postMessage(
                   channelId,
-                  'Dobre, už som si ťa zapísal :) Môžeš si teraz objednávať v channely ' +
+                  'Dobre, už som si ťa zapísal :) Môžeš si teraz objednávať cez kanál ' +
                   '#obedy tak, že napíšeš `@obedbot [tvoja objednávka]`',
                   {as_user: true}
                 );


### PR DESCRIPTION
Update Slovak texts, so that they do not use foreign language words or slang words and unify their style. Also, fix a broken link and add the recently added command `/mizza` to the help message.